### PR TITLE
Revert "Fix ipify timeout issue"

### DIFF
--- a/src/PathGenerator.php
+++ b/src/PathGenerator.php
@@ -32,13 +32,17 @@ class PathGenerator
             }
         }
 
-        return preg_replace('#/+#', '/', implode('/', $paths));
+        return preg_replace('#/+#', '/', join('/', $paths));
     }
 
     protected function remoteHostEqualsLocalHost(string $remoteHost): bool
     {
-        $publicIp = Http::get('https://api64.ipify.org?format=json')->json('ip');
+        $ip = Http::get('https://api.ipify.org/?format=json')->json('ip');
 
-        return $publicIp === $remoteHost;
+        if ($ip !== $remoteHost) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Reverts aerni/laravel-sync#3 as changing the API endpoint was actually a breaking change. If your server is setup for both IPv4 and IPv6, the endpoint will return the IPv6. But you will have configured the IPv4 as the host in the config of this package. So running the sync command won't work anymore without changing the host to IPv6. So this is a breaking change that should be a major release. Or better, finding a non-breaking solution to the timeout issue.